### PR TITLE
allow admin build rake taks to take password

### DIFF
--- a/lib/railties/tasks.rake
+++ b/lib/railties/tasks.rake
@@ -8,15 +8,14 @@ namespace :casein do
     desc "Create default admin user"
     task create_admin: :environment do
 
-      raise "Usage: specify email address, e.g. rake [task] email=mail@caseincms.com" unless ENV.include?("email")
-
-      random_password = random_string = SecureRandom.hex
-      admin = Casein::AdminUser.new({ login: 'admin', name: 'Admin', email: ENV['email'], access_level: $CASEIN_USER_ACCESS_LEVEL_ADMIN, password: random_password, password_confirmation: random_password })
+      raise "Usage: specify email address, e.g. rake [task] email=mail@caseincms.com [(optional) password=mypassword]" unless ENV.include?("email")
+      password = ENV['password'] || SecureRandom.hex
+      admin = Casein::AdminUser.new({ login: 'admin', name: 'Admin', email: ENV['email'], access_level: $CASEIN_USER_ACCESS_LEVEL_ADMIN, password: password, password_confirmation: password })
 
       unless admin.save
         puts "[Casein] Failed: check that the 'admin' account doesn't already exist."
       else
-        puts "[Casein] Created new admin user with username 'admin' and password '#{random_password}'"
+        puts "[Casein] Created new admin user with username 'admin' and password '#{password}'"
       end
     end
 


### PR DESCRIPTION
I've scripted up the initial deployment (to heroku) and wanted to setup the admin account with a known password in my scripts.  So I modified this task a bit so you could optionally add a password for the `create_admin` task.
