### PR TITLE
Fix issue with missing `model_name` method.

### DIFF
--- a/app/views/casein/admin_user_sessions/new.html.erb
+++ b/app/views/casein/admin_user_sessions/new.html.erb
@@ -1,4 +1,4 @@
-<%= form_for @admin_user_session, :url => casein_admin_user_session_path do |f| %>
+<%= form_for @admin_user_session, :url => casein_admin_user_session_path, :as => :casein_admin_user_session do |f| %>
 	<% if @admin_user_session.errors.any? %>
 		<div id="error_messages" class="alert alert-danger">
 			<% @admin_user_session.errors.keys.each do |key| %>


### PR DESCRIPTION
Rails doesn't like `form_for` being handed something that's not an AR model without an `:as` option being supplied.