### PR TITLE
Allow custom css/js in auth layout

### DIFF
--- a/app/views/layouts/casein_auth.html.erb
+++ b/app/views/layouts/casein_auth.html.erb
@@ -5,8 +5,15 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
     <title>Welcome to <%= casein_config_website_name %></title>
-    <%= stylesheet_link_tag "casein/login" %>
-    <%= javascript_include_tag "casein/casein" %>
+    <% casein_config_stylesheet_includes.each do |stylesheet| %>
+      <%= stylesheet_link_tag(stylesheet) %>
+    <% end %>
+    <%= stylesheet_link_tag("casein/login") %>
+
+    <% casein_config_javascript_includes.each do |javascript| %>
+      <%= javascript_include_tag(javascript) %>
+    <% end %>
+
     <%= csrf_meta_tag %>
 
     <!-- HTML5 shim, for IE6-8 support of HTML5 elements -->

--- a/app/views/layouts/casein_auth.html.erb
+++ b/app/views/layouts/casein_auth.html.erb
@@ -8,7 +8,6 @@
     <% casein_config_stylesheet_includes.each do |stylesheet| %>
       <%= stylesheet_link_tag(stylesheet) %>
     <% end %>
-    <%= stylesheet_link_tag("casein/login") %>
 
     <% casein_config_javascript_includes.each do |javascript| %>
       <%= javascript_include_tag(javascript) %>

--- a/lib/generators/casein/install/templates/app/helpers/casein/config_helper.rb
+++ b/lib/generators/casein/install/templates/app/helpers/casein/config_helper.rb
@@ -33,7 +33,7 @@ module Casein
   
     # A list of stylesheets to include. Do not remove the core casein/casein, but you can change the load order, if required.
     def casein_config_stylesheet_includes
-      %w[casein/casein casein/custom]
+      %w[casein/login casein/casein casein/custom]
     end
   
     # A list of JavaScript files to include. Do not remove the core casein/casein, but you can change the load order, if required.


### PR DESCRIPTION
This would allow for sites to use JS/CSS customization in the `casein_auth` layout that’s currently only available in the `casein_main` layout.

Note the hacky manual addition of the `casein/login` CSS . . . there may be a cleaner way to do that.

@russellquinn @mkunkel Let me know if you have any thoughts before I merge this one.