### PR TITLE
fix plural_route when it is not singluar name

### DIFF
--- a/lib/generators/casein/scaffold/scaffold_generator.rb
+++ b/lib/generators/casein/scaffold/scaffold_generator.rb
@@ -18,7 +18,7 @@ module Casein
     end
 
     def generate_files
-      @plural_route = (plural_name != singular_name) ? plural_name : "#{plural_name}_index"
+      @plural_route = plural_name
       @read_only = options[:read_only]
       @no_index = options[:no_index]
 


### PR DESCRIPTION
casein_#(plural_name)_index is not found, but casein_#(plural_name)_path is found in rails 5.0.2.