### PR TITLE
bump authlogic version and gem minor version

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -14,6 +14,10 @@ This version of Casein is designed for Ruby on Rails 5.x and Ruby 2.3.3 or later
 
 Casein 5.1.1.5 was the last gem release compatible with Rails 4.x.
 
+==What’s New in 5.5.0
+
+* Updates minimum version of AuthLogic to 6.1 to resolve compatibility with Ruby 2.7
+
 ==What’s New in 5.4.0
 
 * Bug fix for breaking AuthLogic changes

--- a/casein.gemspec
+++ b/casein.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.name        = 'casein'
   s.version     = Casein::VERSION
   s.authors     = ['Russell Quinn']
-  s.date        = '2019-01-17'
+  s.date        = '2020-08-02'
   s.description = 'A lightweight CMS toolkit for Ruby on Rails, based on Bootstrap.'
   s.summary     = 'A lightweight CMS toolkit for Ruby on Rails, based on Bootstrap.'
   s.email       = ['mail@russellquinn.com']
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
     'README.rdoc'
   ]
 
-  s.add_dependency 'authlogic', '~> 5.0.2'
+  s.add_dependency 'authlogic', '~> 6.1'
   s.add_dependency 'bootstrap-sass', '~> 3.4.0'
   s.add_dependency 'jquery-rails', '>= 0'
   s.add_dependency 'sassc-rails', '>= 2.0.0'

--- a/lib/casein/version.rb
+++ b/lib/casein/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 module Casein
-  VERSION_HASH = { major: 5, minor: 4, patch: 0, build: 0 }
+  VERSION_HASH = { major: 5, minor: 5, patch: 0, build: 0 }
   VERSION = VERSION_HASH.values.join('.')
 end


### PR DESCRIPTION
Authlogic < 6.1.0 emits deprecation warnings in Ruby 2.7, but these are fixed in authlogic 6.1.0 and above.

This PR bumps the authlogic version to `~> 6.0` and also bumps the Casein minor version to `5.5.0.0`.