### PR TITLE
Fix for rails 6.2/7: ActiveModel::Errors#keys deprecated

### DIFF
--- a/app/assets/stylesheets/casein/casein.scss
+++ b/app/assets/stylesheets/casein/casein.scss
@@ -1,4 +1,4 @@
-@import 'bootstrap-sprockets';
+@import "bootstrap/functions";
 @import 'bootstrap';
 @import 'casein-bootstrap-overrides';
 

--- a/app/assets/stylesheets/casein/login.scss
+++ b/app/assets/stylesheets/casein/login.scss
@@ -1,4 +1,4 @@
-@import "bootstrap-sprockets";
+@import "bootstrap/functions";
 @import "bootstrap";
 @import "casein-bootstrap-overrides";
 

--- a/app/views/casein/admin_user_sessions/new.html.erb
+++ b/app/views/casein/admin_user_sessions/new.html.erb
@@ -1,7 +1,7 @@
 <%= form_for @admin_user_session, url: casein_admin_user_session_path do |f| %>
 	<% if @admin_user_session.errors.any? %>
 		<div id="error_messages" class="alert alert-danger">
-			<% @admin_user_session.errors.keys.each do |key| %>
+			<% @admin_user_session.errors.attribute_names.each do |key| %>
 				<%= (key.to_s.humanize + " ") unless key == :base %>
 				<%=  @admin_user_session.errors[key].first %>
 			<% end %>

--- a/casein.gemspec
+++ b/casein.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   ]
 
   s.add_dependency 'authlogic', '~> 6.1'
-  s.add_dependency 'bootstrap-sass', '~> 3.4.0'
+  s.add_dependency 'bootstrap', '~> 5.3.3'
   s.add_dependency 'jquery-rails', '>= 0'
   s.add_dependency 'sassc-rails', '>= 2.0.0'
   s.add_dependency 'scrypt', '>= 1.2.1'

--- a/lib/casein/engine.rb
+++ b/lib/casein/engine.rb
@@ -2,7 +2,7 @@
 
 require 'casein'
 require 'rails'
-require 'bootstrap-sass'
+require 'bootstrap'
 require 'jquery-rails'
 
 module Casein

--- a/lib/casein/version.rb
+++ b/lib/casein/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 module Casein
-  VERSION_HASH = { major: 5, minor: 5, patch: 2, build: 0 }
+  VERSION_HASH = { major: 5, minor: 5, patch: 3, build: 0 }
   VERSION = VERSION_HASH.values.join('.')
 end

--- a/lib/casein/version.rb
+++ b/lib/casein/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 module Casein
-  VERSION_HASH = { major: 5, minor: 5, patch: 1, build: 0 }
+  VERSION_HASH = { major: 5, minor: 5, patch: 2, build: 0 }
   VERSION = VERSION_HASH.values.join('.')
 end


### PR DESCRIPTION
Fix casein for rails 6.2/7: ActiveModel::Errors#keys deprecated

ActiveModel::Errors#keys is removed in rails >= 6.2and causes an error.

This PR Changed admin_user_session.errors.keys.each to admin_user_session.errors.attribute_names.each.

For details see https://github.com/activeadmin/activeadmin/issues/7175